### PR TITLE
fix: Add support for default exported class

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,7 +90,7 @@ function getLineNumberFor(
       regex = /styles:/;
       break;
     case "class":
-      regex = /export class/;
+      regex = /export\s+(default\s+)?class/;
       break;
   }
 


### PR DESCRIPTION
As Angular 15 supports lazy loading component with syntax `() => import('path/to/component')` if the component is default exported. This PR adds support to navigate to component class which is declared as `export default class`